### PR TITLE
use `parse-github-url` instead

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,8 +6,9 @@
  */
 
 var url = require('url');
-var chalk = require('chalk');
+var red = require('ansi-red');
 var origin = require('remote-origin-url');
+var parse = require('parse-github-url');
 
 /**
  * Expose `username`
@@ -20,22 +21,14 @@ module.exports = username;
  */
 
 function username(cwd, verbose) {
-  var repo = origin.sync(cwd);
-  if (!repo && verbose) {
-    console.error(chalk.red('  Can\'t calculate git-username, which probably means that\n  a git remote origin has not been defined.'));
+  var url = origin.sync(cwd);
+  if (!url && verbose) {
+    console.error(red('  Can\'t calculate git-username, which probably means that\n  a git remote origin has not been defined.'))
+  }
+  if (!url) {
+    return null
   }
 
-  if (!repo) {
-    return null;
-  }
-
-  var o = url.parse(repo);
-  var path = o.path;
-
-  if (path.length && path.charAt(0) === '/') {
-    path = path.slice(1);
-  }
-
-  path = path.split('/')[0];
-  return path;
+  var json = parse(url)
+  return json ? json.user : null;
 }

--- a/package.json
+++ b/package.json
@@ -29,20 +29,21 @@
     "test": "mocha"
   },
   "dependencies": {
-    "chalk": "^1.0.0",
+    "ansi-red": "^0.1.1",
+    "parse-github-url": "^0.1.1",
     "remote-origin-url": "^0.4.0"
   },
   "devDependencies": {
     "mocha": "*"
   },
   "keywords": [
-    "parse",
     "git",
     "name",
     "origin",
+    "parse",
     "remote",
-    "remote origin url",
     "remote origin",
+    "remote origin url",
     "url",
     "user",
     "username"


### PR DESCRIPTION
also switch to `ansi-red` instead of `chalk`

PR is, because it not works with other urls different than HTTPS, like `git@github.com:tunnckoCore/git-username.git`

remote origin

``` ini
[core]
    repositoryformatversion = 0
    filemode = true
    bare = false
    logallrefupdates = true
[remote "origin"]
    url = git@github.com:tunnckoCore/git-username.git
    fetch = +refs/heads/*:refs/remotes/origin/*
[branch "master"]
    remote = origin
    merge = refs/heads/master

```
