### PR TITLE
Support ssh formatted git urls

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,6 +34,11 @@ function username(cwd, verbose) {
 
   if (path.length && path.charAt(0) === '/') {
     path = path.slice(1);
+  } else {
+    var match = /^git@\S+:(\S+)\//.exec(path)
+    if (match && match[1]) {
+      path = match[1];
+    }
   }
 
   path = path.split('/')[0];


### PR DESCRIPTION
It seems that current version of `git-username` doesn't support git repos where it's cloned over ssh and the origin url is in following format: `git@github.com:${USER}/{REPO}.git`
